### PR TITLE
Add license and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PDToastKit authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# PDToastKit
+
+PDToastKit is a lightweight Swift package that presents temporary toast messages in SwiftUI.
+
+## Features
+
+- Present toasts from the top or bottom edge
+- Success, warning, error and thanks styles
+- Optional additional message and thumbnail
+- Automatic dismissal after a short duration
+
+## Installation
+
+Add `PDToastKit` to your package dependencies:
+
+```swift
+.package(url: "https://github.com/your/PDToastKit.git", from: "0.1.0")
+```
+
+Then include `PDToastKit` as a dependency of your target.
+
+## Usage
+
+Create a `PDToastManager` and attach a `stackedToast` overlay:
+
+```swift
+@State private var toast = PDToastManager()
+
+var body: some View {
+    ContentView()
+        .stackedToast(manager: toast)
+}
+```
+
+Present a toast using the manager:
+
+```swift
+toast.present(.top, .success("Copied"))
+```
+
+See `Previews.swift` for more examples.
+
+## License
+
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add MIT LICENSE
- add README with usage and installation notes

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*