### PR TITLE
Update license copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PDToastKit authors
+Copyright (c) 2025 lynnSwap
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update year and name in LICENSE to `2025 lynnSwap`

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*