### PR TITLE
Rename additionalMessage to detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PDToastKit is a lightweight Swift package that presents temporary toast messages
 - Present toasts from the top or bottom edge
  - Success, warning, error and thanks styles
  - Create custom toast types in extensions
-- Optional additional message and thumbnail
+- Optional detail message and thumbnail
 - Automatic dismissal after a short duration
 
 ## Installation

--- a/Sources/PDToastKit/Examples/Previews.swift
+++ b/Sources/PDToastKit/Examples/Previews.swift
@@ -18,7 +18,7 @@ struct ToastExampleView: View {
                     .top,
                     .error,
                     "Failed",
-                    additionalMessage: "Something went wrong"
+                    detail: "Something went wrong"
                 )
             }
             Button(String("Show Thanks with Image")) {

--- a/Sources/PDToastKit/Managers/PDToastManager.swift
+++ b/Sources/PDToastKit/Managers/PDToastManager.swift
@@ -12,16 +12,16 @@ import Observation
         _ edge: ToastEdge,
         _ type: ToastType,
         _ message: String,
-        additionalMessage: String? = nil,
+        detail: String? = nil,
         imageURL: URL? = nil,
         imageURLString: String? = nil
     ) {
         if let imageURL {
-            self._present(edge, type, message: message, additionalMessage: additionalMessage, imageUrl: imageURL)
+            self._present(edge, type, message: message, detail: detail, imageUrl: imageURL)
         } else if let imageURLString {
-            self._present(edge, type, message: message, additionalMessage: additionalMessage, imageUrl: URL(string: imageURLString))
+            self._present(edge, type, message: message, detail: detail, imageUrl: URL(string: imageURLString))
         } else {
-            self._present(edge, type, message: message, additionalMessage: additionalMessage, imageUrl: nil)
+            self._present(edge, type, message: message, detail: detail, imageUrl: nil)
         }
     }
 
@@ -29,7 +29,7 @@ import Observation
         _ edge: ToastEdge,
         _ type: ToastType,
         localized key: LocalizedStringResource,
-        additionalMessage: String? = nil,
+        detail: String? = nil,
         imageURL: URL? = nil,
         imageURLString: String? = nil
     ) {
@@ -38,7 +38,7 @@ import Observation
             edge,
             type,
             String(localized:key),
-            additionalMessage: additionalMessage,
+            detail: detail,
             imageURL: imageURL,
             imageURLString: imageURLString
         )
@@ -48,14 +48,14 @@ import Observation
         _ edge: ToastEdge,
         _ type: ToastType,
         message: String,
-        additionalMessage: String?,
+        detail: String?,
         imageUrl: URL?
     ) {
         Task {
             let item = ToastItem(
                 type: type,
                 message: message,
-                additionalMessage: additionalMessage,
+                detail: detail,
                 imageUrl: imageUrl,
                 edge: edge
             )

--- a/Sources/PDToastKit/Models/ToastItem.swift
+++ b/Sources/PDToastKit/Models/ToastItem.swift
@@ -4,20 +4,20 @@ public class ToastItem: Identifiable {
     public let id = UUID()
     let type: ToastType
     let message: String
-    let additionalMessage: String?
+    let detail: String?
     let imageUrl: URL?
     let edge: ToastEdge
 
     init(
         type: ToastType,
         message: String,
-        additionalMessage: String? = nil,
+        detail: String? = nil,
         imageUrl: URL? = nil,
         edge: ToastEdge
     ) {
         self.type = type
         self.message = message
-        self.additionalMessage = additionalMessage
+        self.detail = detail
         self.imageUrl = imageUrl
         self.edge = edge
     }

--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -22,8 +22,8 @@ struct BottomToastView: View {
                     .foregroundStyle(.primary)
                     .font(.callout)
                     .padding(.leading, 6)
-                if let additionalMessage = item.additionalMessage {
-                    Text(additionalMessage)
+                if let detail = item.detail {
+                    Text(detail)
                         .foregroundStyle(.primary)
                         .font(.caption)
                         .padding(.leading, 6)

--- a/Sources/PDToastKit/Views/TopToastView.swift
+++ b/Sources/PDToastKit/Views/TopToastView.swift
@@ -27,8 +27,8 @@ struct TopToastView: View {
                             .foregroundColor(.primary)
                             .font(.callout)
                             .padding(.leading, 6)
-                        if let additionalMessage = item.additionalMessage{
-                            Text(additionalMessage)
+                        if let detail = item.detail{
+                            Text(detail)
                                 .foregroundColor(.secondary)
                                 .font(.caption)
                                 .padding(.leading, 6)


### PR DESCRIPTION
## Summary
- rename `additionalMessage` property to `detail`
- update toast views and preview calls
- update README description

## Testing
- `swift build` *(fails: no such module `SwiftUI`)*
- `swift test` *(fails: no such module `SwiftUI`)*