### PR TITLE
Update README with detail usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Use a localization key by specifying the `localized` argument:
 toast.present(.top, .success, localized: "toast_copied")
 ```
 
+Include additional information with the `detail` parameter:
+
+```swift
+toast.present(.top, .error, "Failed", detail: "Something went wrong")
+```
+
 Create a custom toast type:
 
 ```swift


### PR DESCRIPTION
## Summary
- document `detail` parameter example in README

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683d7ed376508325a023a6db7d041f97