### PR TITLE
Add dismissal pause on toast tap

### DIFF
--- a/Sources/PDToastKit/Examples/Previews.swift
+++ b/Sources/PDToastKit/Examples/Previews.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG && canImport(SwiftUI)
 import SwiftUI
 
 struct ToastExampleView: View {

--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -10,8 +10,13 @@ struct StackedToastView: View {
         ZStack{
             VStack {
                 ForEach(manager.topToasts) { toast in
-                    TopToastView(item:toast)
-                        .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
+                    TopToastView(item: toast)
+                        .onTapGesture { manager.dismiss(toast) }
+                        .simultaneousGesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { _ in manager.pauseDismissTimer(for: toast) }
+                                .onEnded { _ in manager.resumeDismissTimer(for: toast) }
+                        )
                 }
                 Spacer()
             }
@@ -20,8 +25,13 @@ struct StackedToastView: View {
             VStack {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
-                    BottomToastView(item:toast)
-                        .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
+                    BottomToastView(item: toast)
+                        .onTapGesture { manager.dismiss(toast) }
+                        .simultaneousGesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { _ in manager.pauseDismissTimer(for: toast) }
+                                .onEnded { _ in manager.resumeDismissTimer(for: toast) }
+                        )
                 }
             }
             .padding(.bottom, paddingBottom)


### PR DESCRIPTION
## Summary
- support pausing toast dismissal while touching
- handle Linux builds by guarding Preview code

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688578233704832599f2fe764a16b219