### PR TITLE
Enable hold-to-pause on toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ PDToastKit is a lightweight Swift package that presents temporary toast messages
  - Create custom toast types in extensions
 - Optional detail message and thumbnail
 - Automatic dismissal after a short duration
+- Dismiss timer pauses while touching the toast
 
 ## Installation
 

--- a/Sources/PDToastKit/Managers/PDToastManager.swift
+++ b/Sources/PDToastKit/Managers/PDToastManager.swift
@@ -62,13 +62,34 @@ import Observation
             switch edge{
             case .top:
                 topToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                topToasts.removeAll(where: { $0.id == item.id })
+                await self.monitor(item: item, in: &topToasts)
             case .bottom:
                 bottomToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                bottomToasts.removeAll(where: { $0.id == item.id })
+                await self.monitor(item: item, in: &bottomToasts)
             }
+        }
+    }
+
+    private func monitor(item: ToastItem, in array: inout [ToastItem]) async {
+        var remaining = item.type.duration
+        while remaining > 0 {
+            try? await Task.sleep(for: .milliseconds(100))
+            if !item.isPaused {
+                remaining -= 0.1
+            }
+        }
+        array.removeAll(where: { $0.id == item.id })
+    }
+
+    func pause(_ id: UUID) {
+        if let item = topToasts.first(where: { $0.id == id }) ?? bottomToasts.first(where: { $0.id == id }) {
+            item.isPaused = true
+        }
+    }
+
+    func resume(_ id: UUID) {
+        if let item = topToasts.first(where: { $0.id == id }) ?? bottomToasts.first(where: { $0.id == id }) {
+            item.isPaused = false
         }
     }
 }

--- a/Sources/PDToastKit/Models/ToastItem.swift
+++ b/Sources/PDToastKit/Models/ToastItem.swift
@@ -7,6 +7,7 @@ public class ToastItem: Identifiable {
     let detail: String?
     let imageUrl: URL?
     let edge: ToastEdge
+    var isPaused: Bool = false
 
     init(
         type: ToastType,

--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 struct BottomToastView: View {
     public var item: ToastItem
+    var manager: PDToastManager
     @State private var animate: Bool = false
     
     var body: some View {
@@ -57,6 +58,11 @@ struct BottomToastView: View {
             try? await Task.sleep(for: .seconds(0.1))
             animate = true
         }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in manager.pause(item.id) }
+                .onEnded { _ in manager.resume(item.id) }
+        )
     }
 }
 private extension View{
@@ -87,7 +93,8 @@ private extension View{
             message: "Thanks",
             imageUrl: URL(string: "https://avatars.githubusercontent.com/u/65545348?s=64"),
             edge: .bottom
-        )
+        ),
+        manager: PDToastManager()
     )
 }
 #endif

--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -10,8 +10,8 @@ struct StackedToastView: View {
         ZStack{
             VStack {
                 ForEach(manager.topToasts) { toast in
-                    TopToastView(item:toast)
-                        .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
+                    TopToastView(item: toast, manager: manager)
+                        .onTapGesture { manager.topToasts.removeAll(where: { $0.id == toast.id }) }
                 }
                 Spacer()
             }
@@ -20,8 +20,8 @@ struct StackedToastView: View {
             VStack {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
-                    BottomToastView(item:toast)
-                        .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
+                    BottomToastView(item: toast, manager: manager)
+                        .onTapGesture { manager.bottomToasts.removeAll(where: { $0.id == toast.id }) }
                 }
             }
             .padding(.bottom, paddingBottom)

--- a/Sources/PDToastKit/Views/TopToastView.swift
+++ b/Sources/PDToastKit/Views/TopToastView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct TopToastView: View {
     public var item: ToastItem
+    var manager: PDToastManager
     @State private var animate: Bool = false
 
     var body: some View {
@@ -67,6 +68,11 @@ struct TopToastView: View {
             try? await Task.sleep(for: .seconds(0.1))
             animate = true
         }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in manager.pause(item.id) }
+                .onEnded { _ in manager.resume(item.id) }
+        )
     }
 }
 private extension View{
@@ -96,7 +102,8 @@ private extension View{
             type: .success,
             message: "Copied",
             edge: .top
-        )
+        ),
+        manager: PDToastManager()
     )
 }
 #endif


### PR DESCRIPTION
## Summary
- allow toasts to remain visible while touching
- update manager to pause timers and expose `pause`/`resume`
- document the new behaviour in the README

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688578233704832599f2fe764a16b219