### PR TITLE
Add toast hold to pause dismissal

### DIFF
--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -11,6 +11,13 @@ struct StackedToastView: View {
             VStack {
                 ForEach(manager.topToasts) { toast in
                     TopToastView(item:toast)
+                        .onLongPressGesture(minimumDuration: 0, pressing: { pressing in
+                            if pressing {
+                                manager.pause(toast)
+                            } else {
+                                manager.resume(toast)
+                            }
+                        }, perform: {})
                         .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
                 }
                 Spacer()
@@ -21,6 +28,13 @@ struct StackedToastView: View {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
                     BottomToastView(item:toast)
+                        .onLongPressGesture(minimumDuration: 0, pressing: { pressing in
+                            if pressing {
+                                manager.pause(toast)
+                            } else {
+                                manager.resume(toast)
+                            }
+                        }, perform: {})
                         .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
                 }
             }


### PR DESCRIPTION
## Summary
- keep toast visible when user touches the toast
- track timers in `PDToastManager`
- pause and resume timers on long press

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688578233704832599f2fe764a16b219