### PR TITLE
Add hold-to-pause toast

### DIFF
--- a/Sources/PDToastKit/Examples/Previews.swift
+++ b/Sources/PDToastKit/Examples/Previews.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG && canImport(SwiftUI)
 import SwiftUI
 
 struct ToastExampleView: View {

--- a/Sources/PDToastKit/Extensions/View+Toast.swift
+++ b/Sources/PDToastKit/Extensions/View+Toast.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -16,4 +17,4 @@ extension View {
             )
         )
     }
-}
+#endif

--- a/Sources/PDToastKit/Managers/PDToastManager.swift
+++ b/Sources/PDToastKit/Managers/PDToastManager.swift
@@ -8,6 +8,47 @@ import Observation
 
     public init() {}
 
+    private func scheduleDismiss(_ item: ToastItem) {
+        item.startDate = Date()
+        item.dismissTask = Task { [weak self, weak item] in
+            guard let self, let item else { return }
+            try? await Task.sleep(for: .seconds(item.remainingDuration))
+            self.remove(item)
+        }
+    }
+
+    private func cancelDismiss(_ item: ToastItem) {
+        if let task = item.dismissTask {
+            task.cancel()
+            item.dismissTask = nil
+            if let start = item.startDate {
+                item.remainingDuration -= Date().timeIntervalSince(start)
+            }
+        }
+    }
+
+    func hold(_ item: ToastItem) {
+        cancelDismiss(item)
+    }
+
+    func resume(_ item: ToastItem) {
+        guard item.dismissTask == nil else { return }
+        if item.remainingDuration <= 0 {
+            remove(item)
+        } else {
+            scheduleDismiss(item)
+        }
+    }
+
+    private func remove(_ item: ToastItem) {
+        switch item.edge {
+        case .top:
+            topToasts.removeAll { $0.id == item.id }
+        case .bottom:
+            bottomToasts.removeAll { $0.id == item.id }
+        }
+    }
+
     public func present(
         _ edge: ToastEdge,
         _ type: ToastType,
@@ -51,24 +92,19 @@ import Observation
         detail: String?,
         imageUrl: URL?
     ) {
-        Task {
-            let item = ToastItem(
-                type: type,
-                message: message,
-                detail: detail,
-                imageUrl: imageUrl,
-                edge: edge
-            )
-            switch edge{
-            case .top:
-                topToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                topToasts.removeAll(where: { $0.id == item.id })
-            case .bottom:
-                bottomToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                bottomToasts.removeAll(where: { $0.id == item.id })
-            }
+        let item = ToastItem(
+            type: type,
+            message: message,
+            detail: detail,
+            imageUrl: imageUrl,
+            edge: edge
+        )
+        switch edge {
+        case .top:
+            topToasts.append(item)
+        case .bottom:
+            bottomToasts.append(item)
         }
+        scheduleDismiss(item)
     }
 }

--- a/Sources/PDToastKit/Models/ToastItem.swift
+++ b/Sources/PDToastKit/Models/ToastItem.swift
@@ -7,6 +7,12 @@ public class ToastItem: Identifiable {
     let detail: String?
     let imageUrl: URL?
     let edge: ToastEdge
+    // Remaining time until dismissal
+    var remainingDuration: TimeInterval
+    // Task scheduled to remove the toast
+    var dismissTask: Task<Void, Never>?
+    // Last time the timer was started
+    var startDate: Date?
 
     init(
         type: ToastType,
@@ -20,5 +26,6 @@ public class ToastItem: Identifiable {
         self.detail = detail
         self.imageUrl = imageUrl
         self.edge = edge
+        self.remainingDuration = type.duration
     }
 }

--- a/Sources/PDToastKit/Models/ToastType.swift
+++ b/Sources/PDToastKit/Models/ToastType.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 public struct ToastType {
@@ -30,3 +31,4 @@ extension ToastType {
         Self(iconName: "heart.fill", color: .pink, duration: 6.0)
     }
 }
+#endif

--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -5,8 +5,10 @@
 //  Created by lynnswap on 2025/05/28.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 struct BottomToastView: View {
+    var manager: PDToastManager
     public var item: ToastItem
     @State private var animate: Bool = false
     
@@ -53,6 +55,13 @@ struct BottomToastView: View {
         .padding(.vertical, 8)
         .toastStyle()
         .animation(.default, value: animate)
+        .onLongPressGesture(minimumDuration: 0, pressing: { pressing in
+            if pressing {
+                manager.hold(item)
+            } else {
+                manager.resume(item)
+            }
+        }, perform: {})
         .task {
             try? await Task.sleep(for: .seconds(0.1))
             animate = true
@@ -82,6 +91,7 @@ private extension View{
 #if DEBUG
 #Preview("BottomToastView") {
     BottomToastView(
+        manager: PDToastManager(),
         item: ToastItem(
             type: .thanks,
             message: "Thanks",
@@ -92,3 +102,4 @@ private extension View{
 }
 #endif
 
+#endif

--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 struct StackedToastView: View {
@@ -10,7 +11,7 @@ struct StackedToastView: View {
         ZStack{
             VStack {
                 ForEach(manager.topToasts) { toast in
-                    TopToastView(item:toast)
+                    TopToastView(manager: manager, item: toast)
                         .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
                 }
                 Spacer()
@@ -20,7 +21,7 @@ struct StackedToastView: View {
             VStack {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
-                    BottomToastView(item:toast)
+                    BottomToastView(manager: manager, item: toast)
                         .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
                 }
             }
@@ -30,3 +31,4 @@ struct StackedToastView: View {
         .frame(maxWidth: maxWidth)
     }
 }
+#endif

--- a/Sources/PDToastKit/Views/TopToastView.swift
+++ b/Sources/PDToastKit/Views/TopToastView.swift
@@ -5,10 +5,12 @@
 //  Created by lynnswap on 2025/05/28.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 
 struct TopToastView: View {
+    var manager: PDToastManager
     public var item: ToastItem
     @State private var animate: Bool = false
 
@@ -63,6 +65,13 @@ struct TopToastView: View {
             }
         }
         .animation(.default, value: animate)
+        .onLongPressGesture(minimumDuration: 0, pressing: { pressing in
+            if pressing {
+                manager.hold(item)
+            } else {
+                manager.resume(item)
+            }
+        }, perform: {})
         .task {
             try? await Task.sleep(for: .seconds(0.1))
             animate = true
@@ -86,12 +95,17 @@ private extension View{
             .cornerRadius(20)
             .shadow(radius: 5)
 #endif
+
+#endif
+
+#endif
     }
 }
 
 #if DEBUG
 #Preview("TopToastView") {
     TopToastView(
+        manager: PDToastManager(),
         item: ToastItem(
             type: .success,
             message: "Copied",
@@ -101,3 +115,4 @@ private extension View{
 }
 #endif
 
+#endif


### PR DESCRIPTION
## Summary
- keep toast visible while touching
- wrap SwiftUI code for non-Apple platforms
- update previews to match new APIs

## Testing
- `swift test --parallel` *(fails: no SwiftUI module)*

------
https://chatgpt.com/codex/tasks/task_e_688578233704832599f2fe764a16b219