### PR TITLE
Add touch gestures to keep toast visible

### DIFF
--- a/Sources/PDToastKit/Examples/Previews.swift
+++ b/Sources/PDToastKit/Examples/Previews.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if canImport(SwiftUI) && DEBUG
 import SwiftUI
 
 struct ToastExampleView: View {

--- a/Sources/PDToastKit/Extensions/ToastGestures.swift
+++ b/Sources/PDToastKit/Extensions/ToastGestures.swift
@@ -1,0 +1,91 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct ToastTapGesture: UIGestureRecognizerRepresentable {
+    var onEnded: () -> Void
+
+    class Coordinator: NSObject {
+        var onEnded: () -> Void
+        init(onEnded: @escaping () -> Void) { self.onEnded = onEnded }
+        @objc func tapped() { onEnded() }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onEnded: onEnded) }
+
+    func makeUIGestureRecognizer(context: Context) -> UITapGestureRecognizer {
+        UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.tapped))
+    }
+
+    func updateUIGestureRecognizer(_ uiGestureRecognizer: UITapGestureRecognizer, context: Context) {}
+}
+
+struct ToastLongPressGesture: UIGestureRecognizerRepresentable {
+    var minimumDuration: Double = 0.5
+    var onStart: () -> Void
+    var onEnd: () -> Void
+
+    class Coordinator: NSObject {
+        var onStart: () -> Void
+        var onEnd: () -> Void
+        init(onStart: @escaping () -> Void, onEnd: @escaping () -> Void) {
+            self.onStart = onStart
+            self.onEnd = onEnd
+        }
+        @objc func handle(_ gesture: UILongPressGestureRecognizer) {
+            switch gesture.state {
+            case .began: onStart()
+            case .ended, .cancelled, .failed: onEnd()
+            default: break
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onStart: onStart, onEnd: onEnd) }
+
+    func makeUIGestureRecognizer(context: Context) -> UILongPressGestureRecognizer {
+        let g = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handle(_:)))
+        g.minimumPressDuration = minimumDuration
+        return g
+    }
+
+    func updateUIGestureRecognizer(_ uiGestureRecognizer: UILongPressGestureRecognizer, context: Context) {}
+}
+
+struct ToastPanGesture: UIGestureRecognizerRepresentable {
+    var onStart: () -> Void
+    var onEnd: () -> Void
+
+    class Coordinator: NSObject {
+        var onStart: () -> Void
+        var onEnd: () -> Void
+        init(onStart: @escaping () -> Void, onEnd: @escaping () -> Void) {
+            self.onStart = onStart
+            self.onEnd = onEnd
+        }
+        @objc func handle(_ gesture: UIPanGestureRecognizer) {
+            switch gesture.state {
+            case .began, .changed: onStart()
+            case .ended, .cancelled, .failed: onEnd()
+            default: break
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(onStart: onStart, onEnd: onEnd) }
+
+    func makeUIGestureRecognizer(context: Context) -> UIPanGestureRecognizer {
+        UIPanGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handle(_:)))
+    }
+
+    func updateUIGestureRecognizer(_ uiGestureRecognizer: UIPanGestureRecognizer, context: Context) {}
+}
+
+extension View {
+    func toastInteraction(for item: ToastItem, manager: PDToastManager) -> some View {
+        self
+            .overlay(ToastTapGesture { manager.removeToast(id: item.id) })
+            .overlay(ToastPanGesture(onStart: { item.isInteracting = true }, onEnd: { item.isInteracting = false }))
+            .overlay(ToastLongPressGesture(minimumDuration: 0.3, onStart: { item.isInteracting = true }, onEnd: { item.isInteracting = false }))
+    }
+}
+#endif

--- a/Sources/PDToastKit/Extensions/View+Toast.swift
+++ b/Sources/PDToastKit/Extensions/View+Toast.swift
@@ -1,3 +1,4 @@
+#if canImport(SwiftUI)
 import SwiftUI
 
 extension View {
@@ -17,3 +18,4 @@ extension View {
         )
     }
 }
+#endif

--- a/Sources/PDToastKit/Managers/PDToastManager.swift
+++ b/Sources/PDToastKit/Managers/PDToastManager.swift
@@ -59,16 +59,31 @@ import Observation
                 imageUrl: imageUrl,
                 edge: edge
             )
-            switch edge{
+            switch edge {
             case .top:
                 topToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                topToasts.removeAll(where: { $0.id == item.id })
             case .bottom:
                 bottomToasts.append(item)
-                try? await Task.sleep(for: .seconds(type.duration))
-                bottomToasts.removeAll(where: { $0.id == item.id })
             }
+            await monitor(item: item)
         }
+    }
+
+    private func monitor(item: ToastItem) async {
+        var elapsed: Double = 0
+        let duration = item.type.duration
+        while elapsed < duration {
+            try? await Task.sleep(for: .milliseconds(100))
+            if item.isInteracting {
+                continue
+            }
+            elapsed += 0.1
+        }
+        removeToast(id: item.id)
+    }
+
+    func removeToast(id: UUID) {
+        topToasts.removeAll(where: { $0.id == id })
+        bottomToasts.removeAll(where: { $0.id == id })
     }
 }

--- a/Sources/PDToastKit/Models/ToastItem.swift
+++ b/Sources/PDToastKit/Models/ToastItem.swift
@@ -7,6 +7,7 @@ public class ToastItem: Identifiable {
     let detail: String?
     let imageUrl: URL?
     let edge: ToastEdge
+    var isInteracting: Bool = false
 
     init(
         type: ToastType,

--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -11,7 +11,7 @@ struct StackedToastView: View {
             VStack {
                 ForEach(manager.topToasts) { toast in
                     TopToastView(item:toast)
-                        .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
+                        .toastInteraction(for: toast, manager: manager)
                 }
                 Spacer()
             }
@@ -21,7 +21,7 @@ struct StackedToastView: View {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
                     BottomToastView(item:toast)
-                        .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
+                        .toastInteraction(for: toast, manager: manager)
                 }
             }
             .padding(.bottom, paddingBottom)


### PR DESCRIPTION
## Summary
- use UIKit recognizers to detect tap, pan and long press
- pause toast dismissal while gestures are active
- dismiss toast on tap
- guard SwiftUI code for non-iOS builds

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688599b968688325bc53bf1c0d6edd1f