### PR TITLE
Add toast task registry

### DIFF
--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -10,8 +10,8 @@ struct StackedToastView: View {
         ZStack{
             VStack {
                 ForEach(manager.topToasts) { toast in
-                    TopToastView(item:toast)
-                        .onTapGesture { manager.topToasts.removeAll(where: {$0.id == toast.id}) }
+                    TopToastView(item: toast)
+                        .onTapGesture { manager.dismiss(toast.id) }
                 }
                 Spacer()
             }
@@ -20,8 +20,8 @@ struct StackedToastView: View {
             VStack {
                 Spacer()
                 ForEach(manager.bottomToasts) { toast in
-                    BottomToastView(item:toast)
-                        .onTapGesture { manager.bottomToasts.removeAll(where: {$0.id == toast.id}) }
+                    BottomToastView(item: toast)
+                        .onTapGesture { manager.dismiss(toast.id) }
                 }
             }
             .padding(.bottom, paddingBottom)


### PR DESCRIPTION
## Summary
- keep toast removal `Task`s in a dictionary so they can be cancelled
- use `dismiss` helper in stacked toast view

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6886ee9387dc8325b30406477fcd0832