### PR TITLE
Add long press pause for toasts

### DIFF
--- a/Sources/PDToastKit/Examples/Previews.swift
+++ b/Sources/PDToastKit/Examples/Previews.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG && canImport(SwiftUI)
 import SwiftUI
 
 struct ToastExampleView: View {

--- a/Sources/PDToastKit/Managers/PDToastManager.swift
+++ b/Sources/PDToastKit/Managers/PDToastManager.swift
@@ -83,4 +83,19 @@ import Observation
         topToasts.removeAll { $0.id == id }
         bottomToasts.removeAll { $0.id == id }
     }
+
+    /// Cancel the scheduled dismiss task for the toast.
+    func pause(_ id: UUID) {
+        tasks[id]?.cancel()
+        tasks.removeValue(forKey: id)
+    }
+
+    /// Restart the dismiss task for the toast.
+    func resume(_ item: ToastItem) {
+        let task = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(item.type.duration))
+            self?.expireToast(item.id)
+        }
+        tasks[item.id] = task
+    }
 }

--- a/Sources/PDToastKit/Views/StackedToastView.swift
+++ b/Sources/PDToastKit/Views/StackedToastView.swift
@@ -12,6 +12,16 @@ struct StackedToastView: View {
                 ForEach(manager.topToasts) { toast in
                     TopToastView(item: toast)
                         .onTapGesture { manager.dismiss(toast.id) }
+                        .onLongPressGesture(
+                            perform: { },
+                            onPressingChanged: { pressing in
+                                if pressing {
+                                    manager.pause(toast.id)
+                                } else {
+                                    manager.resume(toast)
+                                }
+                            }
+                        )
                 }
                 Spacer()
             }
@@ -22,6 +32,16 @@ struct StackedToastView: View {
                 ForEach(manager.bottomToasts) { toast in
                     BottomToastView(item: toast)
                         .onTapGesture { manager.dismiss(toast.id) }
+                        .onLongPressGesture(
+                            perform: { },
+                            onPressingChanged: { pressing in
+                                if pressing {
+                                    manager.pause(toast.id)
+                                } else {
+                                    manager.resume(toast)
+                                }
+                            }
+                        )
                 }
             }
             .padding(.bottom, paddingBottom)


### PR DESCRIPTION
## Summary
- handle long presses so toasts remain visible while pressed
- add pause/resume API to `PDToastManager`
- compile previews only when SwiftUI is available

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6886f04cdd988325be1e7dff87627875