### PR TITLE
Replace deprecated foregroundColor usage

### DIFF
--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -15,7 +15,7 @@ struct BottomToastView: View {
             Image(systemName: item.type.iconName)
                 .symbolEffect(.bounce.wholeSymbol, options: .nonRepeating, value: animate)
                 .font(.system(size: 22))
-                .foregroundColor(item.type.color)
+                .foregroundStyle(item.type.color)
                 .padding(.leading, 6)
             VStack(alignment: .leading) {
                 Text(item.message)

--- a/Sources/PDToastKit/Views/TopToastView.swift
+++ b/Sources/PDToastKit/Views/TopToastView.swift
@@ -20,16 +20,16 @@ struct TopToastView: View {
                     Image(systemName: item.type.iconName)
                         .symbolEffect(.bounce.wholeSymbol, options: .nonRepeating, value: animate)
                         .font(.system(size: 22))
-                        .foregroundColor(item.type.color)
+                        .foregroundStyle(item.type.color)
                         .padding(.leading, 6)
                     VStack(alignment: .leading) {
                         Text(item.message)
-                            .foregroundColor(.primary)
+                            .foregroundStyle(.primary)
                             .font(.callout)
                             .padding(.leading, 6)
                         if let detail = item.detail{
                             Text(detail)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .font(.caption)
                                 .padding(.leading, 6)
                         }


### PR DESCRIPTION
## Summary
- replace deprecated `foregroundColor` modifiers with `foregroundStyle`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689da1dd6e8083259504061ae47bc2db