### PR TITLE
Use secondary style for detail in BottomToastView

### DIFF
--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -24,7 +24,7 @@ struct BottomToastView: View {
                     .padding(.leading, 6)
                 if let detail = item.detail {
                     Text(detail)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                         .padding(.leading, 6)
                 }


### PR DESCRIPTION
## Summary
- show secondary color for detail text in BottomToastView

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689da2ceb67c83259c96925c9f721682