### PR TITLE
Use imageScale for toast icons

### DIFF
--- a/Sources/PDToastKit/Views/BottomToastView.swift
+++ b/Sources/PDToastKit/Views/BottomToastView.swift
@@ -14,7 +14,7 @@ struct BottomToastView: View {
         HStack(spacing: 8) {
             Image(systemName: item.type.iconName)
                 .symbolEffect(.bounce.wholeSymbol, options: .nonRepeating, value: animate)
-                .font(.system(size: 22))
+                .imageScale(.large)
                 .foregroundStyle(item.type.color)
                 .padding(.leading, 6)
             VStack(alignment: .leading) {

--- a/Sources/PDToastKit/Views/TopToastView.swift
+++ b/Sources/PDToastKit/Views/TopToastView.swift
@@ -19,7 +19,7 @@ struct TopToastView: View {
                 HStack(spacing: 8) {
                     Image(systemName: item.type.iconName)
                         .symbolEffect(.bounce.wholeSymbol, options: .nonRepeating, value: animate)
-                        .font(.system(size: 22))
+                        .imageScale(.large)
                         .foregroundStyle(item.type.color)
                         .padding(.leading, 6)
                     VStack(alignment: .leading) {


### PR DESCRIPTION
## Summary
- prefer `imageScale(.large)` over fixed font size for toast icons

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689da4413a40832591ca379570254108